### PR TITLE
Adjusts on the parametrization

### DIFF
--- a/XA-and-XD-HealthCheck_Parameters.xml
+++ b/XA-and-XD-HealthCheck_Parameters.xml
@@ -87,14 +87,14 @@
 		<Variable>
 			<!-- Set value for a load of a XenApp server that is be fine, but is needed to escalate -->
 			<Name>loadIndexWarning</Name>
-			<Value>800</Value>
+			<Value>6000</Value>
 			<Type>[int]</Type>
 			<Scope>Global</Scope>
 		</Variable>
 		<Variable>
 			<!-- Set value for a load of a XenApp server that is be critical -->
 			<Name>loadIndexError</Name>
-			<Value>1500</Value>
+			<Value>8500</Value>
 			<Type>[int]</Type>
 			<Scope>Global</Scope>
 		</Variable>


### PR DESCRIPTION
Load Evaluator goes from 0 to 9999. Default values of 800/1500 seems
too low for a production environment.
Adjusted to reflect warning on 60% usage and critical at 85%.