### PR TITLE
Version 1.4.7 update

### DIFF
--- a/XA-and-XD-HealthCheck_Parameters.xml
+++ b/XA-and-XD-HealthCheck_Parameters.xml
@@ -4,7 +4,21 @@
 		<Variable>
 			<!-- Define a EnvironmentName e.g. Integration/Production etc. - this will be used in HTML & Email Subject -->
 			<Name>EnvironmentName</Name>
-			<Value>XenApp and XenDesktop</Value>
+			<Value>Citrix Health Status</Value>
+			<Type>[string]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Define an Output log file e.g CTXXDHealthCheck.log -->
+			<Name>OutputLog</Name>
+			<Value>CTXXDHealthCheck.log</Value>
+			<Type>[string]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Define an Output HTML file e.g CTXXDHealthCheck.html -->
+			<Name>OutputHTML</Name>
+			<Value>CTXXDHealthCheck.htm</Value>
 			<Type>[string]</Type>
 			<Scope>Script</Scope>
 		</Variable>
@@ -26,6 +40,20 @@
 			<!-- Cloud API for Enviornments in Citrix Cloud https://eu.cloud.com/identity/api-access/secure-clients -->
 			<Name>SecureClientFile</Name>
 			<Value>C:\Company\myCredentialfiles\secureclient.csv</Value> <!--  you need to download the CSV file and locate it on the server running this script, e.g the CloudConnector --> 
+			<Type>[string]</Type>
+			<Scope>Script</Scope> <!-- global ? -->
+		</Variable>
+		<Variable>
+			<!-- Cloud API for Enviornments in Citrix Cloud e.g. https://eu.cloud.com/identity/api-access/secure-clients -->
+			<Name>APIKey</Name>
+			<Value>20f97466-76ff-4cfc-ac2a-52790387540a</Value> <!-- this is the GUID ID like 20f97466-76ff-4cfc-ac2a-52790387540a . Only needed when the SecureClientFile is not present -->
+			<Type>[string]</Type>
+			<Scope>Script</Scope> <!-- global ? -->
+		</Variable>
+		<Variable>
+			<!-- Cloud API for Enviornments in Citrix Cloud e.g. https://eu.cloud.com/identity/api-access/secure-clients -->
+			<Name>SecretKey</Name>
+			<Value>eoFfKREqbx620gTrJH0JFA==</Value> <!-- this is the secret like eoFfKREqbx620gTrJH0JFA== . Only needed when the SecureClientFile is not present -->
 			<Type>[string]</Type>
 			<Scope>Script</Scope> <!-- global ? -->
 		</Variable>
@@ -52,6 +80,36 @@
 			<Scope>Script</Scope>
 		</Variable>
 		<Variable>
+			<!-- # Set to 1 if you want to Check a Environment with Cloud Connectors -->
+			<Name>ShowCloudConnectorTable</Name>
+			<Value>0</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Define the hostnames of Cloud Connector Servers, you can use localhost if you run localy
+			     Example: CCS01.domain.tld,CCS02.domain.tld -->
+			<Name>CloudConnectorServers</Name>
+			<Value></Value> <!-- Add Server separated by comma -->
+			<Type>[array]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- # Set to 1 if you want to Check a Environment with Storefront -->
+			<Name>ShowStorefrontTable</Name>
+			<Value>0</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Define the hostnames of Storefront Servers, you can use localhost if you run localy
+			     Example: CXS01.domain.tld,CXS02.domain.tld -->
+			<Name>StoreFrontServers</Name>
+			<Value></Value> <!-- Add Server separated by comma -->
+			<Type>[array]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
 			<!-- Maximum uptime of a virtual Desktop or a XenApp
 				 Example: 7 -->
 			<Name>maxUpTimeDays</Name>
@@ -61,14 +119,25 @@
 		</Variable>
 		<Variable>
 			<!-- Exclude Catalogs, e.g Testing or Poc-Catalogs
-				 Example: Windows 7,Windows 8 Test -->
+				 Example: Windows 7,Windows 8 Test
+				 Supports wildcards -->
 			<Name>ExcludedCatalogs</Name>
 			<Value></Value>
 			<Type>[array]</Type>
 			<Scope>Script</Scope>
 		</Variable>
 		<Variable>
-			<!-- Exclude Tags, e.g excludeFromReport, UAT, etc -->
+			<!-- Exclude Delivery Groups, e.g Testing or Poc-DGs
+				 Example: Windows 7,Windows 8 Test
+				 Supports wildcards -->
+			<Name>ExcludedDeliveryGroups</Name>
+			<Value></Value>
+			<Type>[array]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Exclude Tags, e.g excludeFromReport, UAT, etc
+				 Supports wildcards -->
 			<Name>ExcludedTags</Name>
 			<Value>excludeFromReport</Value>
 			<Type>[array]</Type>
@@ -77,7 +146,27 @@
 		<Variable>
 			<!-- define the maximum of counted machines (default is only 250) -->
 			<Name>maxmachines</Name>
-			<Value>1000</Value>
+			<Value>5000</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Time (In Days) that it will look back for maintenance mode actions
+				 Example: 30
+				 This is handy data to have in the reports so you can see who placed the
+				 machines, Delivery Groups and Hypervisor Connections into maintenance mode -->
+			<Name>MaintenanceModeActionsFromPastinDays</Name>
+			<Value>30</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Time (In Hours) of that it will look back for Broker Connection Failures
+				 Example: 12
+				 If the report is run first thing in the morning, this will help see any
+				 brokering issues that occurred overnight -->
+			<Name>BrokerConnectionFailuresinHours</Name>
+			<Value>12</Value>
 			<Type>[int]</Type>
 			<Scope>Script</Scope>
 		</Variable>
@@ -90,7 +179,7 @@
 			<Scope>Script</Scope>
 		</Variable>
 		<Variable>
-			<!-- Define if you ONLY want to see bad XENAPP (Unregistered, to high Uptime, Ping-Time-out)
+			<!-- Define if you ONLY want to see bad XENAPP (Unregistered, to high Uptime)
 				 I propose to set this value to 1 in not small environments >50 Desktops -->
 			<Name>ShowOnlyErrorXA</Name>
 			<Value>0</Value>
@@ -98,7 +187,7 @@
 			<Scope>Script</Scope>
 		</Variable>
 		<Variable>
-			<!-- Define if you ONLY want to see bad DESKTOPS (Unregistered, to high Uptime, Ping-Time-out)
+			<!-- Define if you ONLY want to see bad DESKTOPS (Unregistered, to high Uptime)
 				 I propose to set this value to 1 in not small environments >50 Desktops -->
 			<Name>ShowOnlyErrorVDI</Name>
 			<Value>0</Value>
@@ -159,11 +248,44 @@
 		<Variable>
 			<!-- # Select types of licenses to report, eg: XDT_PLT_UD, PVSD_STD_CCS -->
 			<Name>CTXLicenseMode</Name>
-			<Value>XDT_PLT_UD,PVSD_STD_CCS</Value>
+			<Value>XDT_PLT_CCS,XDT_PLT_UD,PVSD_STD_CCS</Value>
 			<Type>[array]</Type>
 			<Scope>Script</Scope>
 		</Variable>
-<!-- PVS-Section: If you are using WriteCache to HD -->
+<!-- Stuck Sessions Options -->
+		<Variable>
+			<!-- Set to 1 if you want to process and display the Stuck Sessions Table -->
+			<Name>ShowStuckSessionsTable</Name>
+			<Value>1</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Maximum Disconnect Time (In Hours) of a virtual Desktop or a XenApp host
+				 Example: 8
+				 This will help to evaluate stuck or stale sessions -->
+			<Name>MaxDisconnectTimeInHours</Name>
+			<Value>96</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Exclude user accounts from being flagged as a Stuck Session
+			      Example: kiosk
+				  Supports wildcards -->
+			<Name>ExcludedStuckSessionUserAccounts</Name>
+			<Value>*kiosk*</Value>
+			<Type>[array]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+<!-- MCS/PVS-Section: If you are using WriteCache to HD -->
+		<Variable>
+			<!-- Drive to MCSIO vDisk write cache file -->
+			<Name>MCSIOWriteCacheDrive</Name>
+			<Value>D</Value>
+			<Type>[string]</Type>
+			<Scope>Script</Scope>
+		</Variable>
 		<Variable>
 			<!-- Drive to PVS vDisk write cache file -->
 			<Name>PvsWriteCacheDrive</Name>
@@ -172,8 +294,8 @@
 			<Scope>Script</Scope>
 		</Variable>
 		<Variable>
-			<!-- Size of the local PVS write cache drive -->
-			<Name>PvsWriteMaxSize</Name>
+			<!-- Maximum size of the local PVS (vdiskdif.vhdx) and MCSIO (mcsdif.vhdx) write cache file -->
+			<Name>WriteCacheMaxSizeInGB</Name>
 			<Value>15</Value> <!-- size in GB -->
 			<Type>[long]</Type>
 			<Scope>Script</Scope>
@@ -197,6 +319,13 @@
 			<!-- Address of the recipient -->
 			<Name>emailTo</Name>
 			<Value>citrix@mycompany.ch</Value>
+			<Type>[string]</Type>
+			<Scope>Script</Scope>
+		</Variable>
+		<Variable>
+			<!-- Address of the recipient for CC -->
+			<Name>emailCC</Name>
+			<Value></Value>
 			<Type>[string]</Type>
 			<Scope>Script</Scope>
 		</Variable>


### PR DESCRIPTION
Have completely overhauled the script with the following improvements:

- Bugfix added emailCC to XML
- Added new functions to test for connectivity: Test-Ping, IsWinRMAccessible, IsWMIAccessible, IsUNCPathAccessible
These are fast and efficient for testing base connectivity to the machines before running each test, which helps prevent the functions from waiting for timeouts when connectivity
is a problem.
- Removed the old Ping function. There wasn't anything wrong with it. I was just attempting to improve its efficiency.
- Removed the $wmiOSBlock scriptblock. This is now in a function.
- Removed the OS version check using the version of C:\Windows\System32\hal.dll. This is inefficient, slow and can be inaccurate as the hal.dll version loosely correlates to OS builds, but isn't guaranteed to match OS version of edition exactly. Replaced it with the Get-OSVersion function, which also returns the caption that can be useful for other checks.
- Added new functions for tests: Get-UpTime, Get-OSVersion, Get-NvidiaDetails, Check-NvidiaLicenseStatus, Get-RDSLicensingDetails, Get-PersonalityInfo, Get-WriteCacheDriveInfo
These will help move the code to functions as per future improvements from version 1.5
- Enhanced the following functions to allow for WinRM: CheckCpuUsage, CheckMemoryUsage, CheckHardDiskUsage
- Fixed a bug in the CheckHardDiskUsage function so it won't fail if an ISO is left mounted as the D: drive.
- Added $OutputLog, $OutputHTML, $ShowStuckSessionsTable and $MaxDisconnectTimeInHours variables to XML file.
- Added new Stuck Sessions table and the logic that generates the information so you can quickly see any machines or sessions that may not look healthy.
Some of this logic relies on the $MaxDisconnectTimeInHours variable being set correctly in the parameters XML file.
The only limitation here is that the Get-BrokerSession cmdlet does not have a tags property. So it will not support filtering against the $ExcludedTags array.
Therefore, we use the Get-BrokerMachine cmdlet to filter the $AllStuckSessions collection correctly against the $ExcludedTags array.
- Added 3 new script parameters $ParamsFile, $All and $UseRunspace so the script can be launched from a central server to health check multiple sites in parallel.
- Added Get-LogicalProcessorCount function for the Runspace pool.
- Reordered and improved some of the code so that it flows in and out of the scriptblock.
- Improved some checking on the Delivery Controllers so that it exits the scriptblock if invalid.
- Changed the $LicWMIQuery variable to $LicQuery and enhanced the code so it can use WinRM.
- Implemented Storefront checks from Naveen Arya's version of the script.
- Added ShowStorefrontTable and StoreFrontServers variables to XML file to facilitate the Storefront checks.
- Added ShowCloudConnectorTable and CloudConnectorServers variables to XML file to facilitate the Cloud Connector checks.
- Removed $ControllerVersion -lt 7 code, as this is old and should no longer be needed in this script.
- Added ExcludedDeliveryGroups variable to XML file, as a further option to ExcludedCatalogs and ExcludedTags.  Updated the Check Assignments (Delivery Group Check) with this variable.
Updated the code so they all support wildcards.
- Added more checks to ensure the first element of the ExcludedDeliveryGroups, ExcludedCatalogs and ExcludedTags arrays is not empty. This ensures the script functions if the values in the XML file are left empty.
- Improved the Get-BrokerMachine filtering for SessionSupport, so less objects are returned. This reduces processing time for the Where-Object filtering.
- It's important to note that Cloud PCs are Azure AD joined only, and may be managed by a different group. So it's most likely that you would not have permissions to run health checks against them. Therefore it's recommended to exclude the Catalogs and/or Delivery Groups from these checks.
- The Windows 10/11 Enterprise multi-session hosts are processed as multi-session hosts, but the RDS licensing is not relevant. So the RDS Grace period is marked as N/A and we don't run the Get-RDSLicensingDetails function on those machines.
- Added the HypervisorConnection table and removed the HypervisorConnectionstate from the footer. It didn't make sense to have it there.
- As the HTML <td> width attribute is deprecated in HTML5 and now considered obsolete, uncommented the CSS from the writeHtmlHeader function and added "width: fit-content" to the td.
- Have removed the $headerWidths requirement for the writeTableHeader function and from the remainder of the script.
- Whilst we can use "white-space: nowrap" to prevent a line-break at hyphen in the HTML, this will make the table too wide. Therefore modified the writeData function to replace hyphens with a non-breaking hyphen before it writes the data to the table.
- Removed WriteCacheSize from tables in favour of vhdxSize_inMB. It makes more sense for PVS and MCSIO.
- Renamed MCSVDIImageOutOfDate to MCSImageOutOfDate and added this to the XenApp/RDS/Multisession host checks.
- Added the MCSIOWriteCacheDrive variable to the XML file to pass to the Get-WriteCacheDriveInfo function in line with PvsWriteCacheDrive.
- Renamed the PvsWriteMaxSize variable to WriteCacheMaxSizeInGB in the XML file, and removed the PvsWriteMaxSizeInGB variable altogether, which makes sense for both PVS, when assessing the size of the vdiskdif.vhdx file, and MCSIO, when assessing the size of the mcsdif.vhdx file. This is used against the output of the Get-WriteCacheDriveInfo function.
- The output to the "vhdxSize_inGB" column now goes to 3 decimal points, which allows us to see the 4MB default value after a reboot. This way we know it's all good and healthy.
- Added the "MasterImageVMDate", "UseFullDiskClone", "UseWriteBackCache", "WriteBackCacheMemSize" columns to the Check Catalog table using the Get-ProvScheme cmdlet.
- If the MasterImageVMDate is older than 90 days, mark it as a warning as it's missed patching cycles.
- Check the Machine Catalog ProvisioningType that the machine belongs to is MCS before filing out the MCSImageOutOfDate column. This reduces confusion.
- Added ShowOnlyErrorXA and ErrorXA back into the logic like ShowOnlyErrorVDI and ErrorVDI.
- Added a new table for "ConnectionFailureOnMachine" that uses the Get-BrokerConnectionLog cmdlet.
- Added a new variable called BrokerConnectionFailuresinHours to the XML file used by the ConnectionFailureOnMachine check. If the report is run first thing in the morning, this will help see any brokering issues that occurred overnight.
- Machine Creation Services (MCS) supports using Azure Ephemeral OS disk for non-persistent VMs. Ephemeral disks should be fast IO because it uses temp storage on the local host.
- MCSIO is not compatible with Azure Ephemeral Disks, and is therefore not an available configuration.
- Added a Get-BrokerTag section to create the $ActualExcludedBrokerTags and $ActualIncludedBrokerTags arrays used for filtering
- The script will generate 6 new arrays as it processes the Machine Catalogs, Delivery Groups and Tags: $ActualExcludedCatalogs, $ActualIncludedCatalogs, $ActualExcludedDeliveryGroups,
$ActualIncludedDeliveryGroups, $ActualExcludedBrokerTags, $ActualIncludedBrokerTags
This helps us filter out the $ExcludedCatalogs, $ExcludedDeliveryGroups, $ExcludedTags by simply using wildcards. This works well if you have naming standards for these items such as
"*Remote PC*", "*Cloud PC*", etc.
- Added the MaintModeReason info to the MaintMode column for the VDI (singlesession) and XenApp/RDSH (multisession) tests. This is handy if an Administrator has recorded why they have placed a machine into maintenance mode, such as draining the sessions, a change record, etc.
- Removed the Get-CitrixMaintenanceInfo function as we are now calling the Get-LogLowLevelOperation cmdlet directly, but still using the methodology the Stefan Beckmann created. Will revisit PS Remoting for sections of the script in a future version. Enhanced it further so we can also get information for who placed Delivery Groups and Hypervisor Connections into
maintenance mode. Added PropertyName and TargetType to the output to help with debugging.
- Added the $MaintenanceModeActionsFromPastinDays variable to the XML file. It is used for the Get-LogLowLevelOperation cmdlet so we know how far back to go to get maintenance mode actions.
- Added the Test-OpenPort function that uses the Test-NetConnection cmdlet to test for Port 80 and 443 to the Delivery Controllers, which is needed for the PowerShell SDK. This replaces the Test-Connection cmdlet, which only sends ICMP echo request packets (pings). Not only is a ping a poor test to validate a Delivery Controller, OT environments are also
typically locked down where even pings are not allowed through. This could even be further enhanced to do an XDPing to check the Broker's Registrar service. That function can be found here: https://www.jhouseconsulting.com/2019/05/16/xdping-powershell-function-1931
- Added minor updates to the New-XMLVariables function so it's easier to debug.
- Added the $ExcludedStuckSessionUserAccounts variable to the XML file. It is used to exclude certain sessions from the Stuck Sessions table. It supports wildcards. The purpose of this is to exclude kiosk accounts that may stay logged in for long periods of time.
- Enhanced the Uptime VDI (single-session) and XenApp/RDSH (multi-session) tests so that they are marked as an error when Uptime is $maxUpTimeDays x 3.
