### PR TITLE
Version 1.5.2 update

### DIFF
--- a/XA-and-XD-HealthCheck_Parameters.xml
+++ b/XA-and-XD-HealthCheck_Parameters.xml
@@ -170,6 +170,13 @@
 			<Type>[int]</Type>
 			<Scope>Script</Scope>
 		</Variable>
+		<Variable>
+			<!-- # Set to 1 if you want to Show and Check the CrowdStrike Tests in all tables -->
+			<Name>ShowCrowdStrikeTests</Name>
+			<Value>1</Value>
+			<Type>[int]</Type>
+			<Scope>Script</Scope>
+		</Variable>
 <!-- XenDesktop Options -->
 		<Variable>
 			<!-- # Set to 1 if you want to Check a Environment with XenDesktop (V 5.x and higher) -->


### PR DESCRIPTION
- Updated the Citrix Cloud (DaaS) authentication process allowing for the change in the way the AdminAddress (AKA XDSDKProxy) has been removed as a Global variable and now stored in as a key/value pair under the NonPersistentMetadata property of the Get-XDCredentials cmdlet output.
- Updated the Check-NvidiaLicenseStatus to use a switch statement instead of an if/else block. Improved the logic and outputs to help track common issues when licensing fails.
- Added the Get-CrowdStrikeServiceStatus function to check and audit CrowdStrike Windows Sensor information.
- Added the CSEnabled and CSGroupTags columns to the tables. CSEnabled means that CrowdStrike is installed and running with an Agent ID. CSGroupTags are the Sensor group tags used when installed. This gives us a nice way to audit where it's missing and which tags have been used to ensure we have consistency. This relies on WinRM being enabled across all hosts.
- Added the $ShowCrowdStrikeTests variable to the XML file.
- Updated the XDPing function.